### PR TITLE
[chore] Remove swagger UI from production mode (#23)

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -11,6 +11,9 @@ async function bootstrap() {
 
   const PORT = configService.getOrThrow<number>('APPLICATION_PORT');
   const HOST = configService.getOrThrow<number>('APPLICATION_HOST');
+  const MODE = configService.getOrThrow<string>('NODE_ENV');
+
+  const isDev = MODE === 'development';
 
   app.useGlobalFilters(new InternalServerErrorFilter());
 
@@ -22,19 +25,20 @@ async function bootstrap() {
     exposedHeaders: ['set-cookie'],
   });
 
-  // TODO: remove from production mode (#23)
-  const config = new DocumentBuilder()
-    .setTitle('Planner API')
-    .setVersion('1.2.0')
-    .setDescription('API для приложения по планированию Planner')
-    .addBearerAuth()
-    .build();
-  const document = SwaggerModule.createDocument(app, config);
-  SwaggerModule.setup('swagger', app, document);
+  if (isDev) {
+    const config = new DocumentBuilder()
+      .setTitle('Planner API')
+      .setVersion('1.2.0')
+      .setDescription('API для приложения по планированию Planner')
+      .addBearerAuth()
+      .build();
+    const document = SwaggerModule.createDocument(app, config);
+    SwaggerModule.setup('swagger', app, document);
+  }
 
   await app.listen(PORT, () => {
     console.log(`API url: http://${HOST}:${PORT}/api`);
-    console.log(`SWAGGER url: http://${HOST}:${PORT}/swagger`);
+    if (isDev) console.log(`SWAGGER url: http://${HOST}:${PORT}/swagger`);
   });
 }
 bootstrap();


### PR DESCRIPTION
## Goal
Hide Swagger UI in production and enable it only in development environment.

Related Issue: #23 

Closes #23 

## Changes
- Added NODE_ENV check before configuring SwaggerModule
- Swagger setup now runs only when NODE_ENV === 'development'
- Removed production Swagger output from application bootstrap

## Type of Change
- [ ] Fix
- [ ] Feature
- [ ] Refactor
- [ ] Enhancement
- [ ] Breaking change
- [x] Chore

## Checklist
- [x] Matches the description in the related Issue
- [x] Code formatted (lint/format)
- [x] Locally tested
- [ ] CI passed
- [x] No unnecessary commits (will be squashed)

## Notes
No breaking changes expected. No migrations required.
